### PR TITLE
Respect BGFX_RESET_FLIP_AFTER_RENDER during Init

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1817,7 +1817,7 @@ namespace bgfx
 		m_frames  = 0;
 		m_debug   = BGFX_DEBUG_NONE;
 		m_frameTimeLast = bx::getHPCounter();
-        m_flipAfterRender = !!(m_init.resolution.reset & BGFX_RESET_FLIP_AFTER_RENDER);
+		m_flipAfterRender = !!(m_init.resolution.reset & BGFX_RESET_FLIP_AFTER_RENDER);
 
 		m_submit->create(_init.limits.minResourceCbSize);
 

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1817,6 +1817,7 @@ namespace bgfx
 		m_frames  = 0;
 		m_debug   = BGFX_DEBUG_NONE;
 		m_frameTimeLast = bx::getHPCounter();
+        m_flipAfterRender = !!(m_init.resolution.reset & BGFX_RESET_FLIP_AFTER_RENDER);
 
 		m_submit->create(_init.limits.minResourceCbSize);
 


### PR DESCRIPTION
Currently BGFX_RESET_FLIP_AFTER_RENDER is only applied when calling bgfx::reset, and ignored when passed in as part of the initialization properties.  This change applies the flag during init in the same way it is applied during reset.